### PR TITLE
Use artifactory-publish credential for publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,11 @@ pipeline {
     stages {
         stage('Publish to Artifactory') {
             steps {
-                publishGradleLibrary(module: ':spannedgridlayoutmanager', release: params.RELEASE)
+                publishGradleLibrary(
+                    module: ':spannedgridlayoutmanager',
+                    release: params.RELEASE,
+                    credentialsId: 'artifactory-publish'
+                )
             }
         }
     }


### PR DESCRIPTION
Points the `publishGradleLibrary` call at a dedicated `artifactory-publish` Jenkins credential (username `builder` + the proven publisher token from c4gradle) instead of the shared `builder` default.

The shared `builder` credential 401'd when used via `maven-publish` Basic auth, even on `libs-snapshot-local` where NavigatorApi publishes fine via the JFrog plugin. This isolates whether the 401 was a credential-value mismatch (this fixes it) or an auth-mechanism issue (then we pivot to the JFrog plugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
